### PR TITLE
fix: add mean_lm statistic as plot fn

### DIFF
--- a/plot_functions.R
+++ b/plot_functions.R
@@ -121,3 +121,6 @@ plot_kernel_density_estimate <- function(df, metric, comparison, period, segment
 plot_population_ratio <- function(...) { plot_mean(..., "population_ratio") }
 
 plot_per_client_dau_impact <- function(...) { plot_mean(..., "per_client_dau_impact") }
+
+plot_mean_lm <- function(...) { plot_mean(..., "mean_lm") }
+


### PR DESCRIPTION
partybal has been failing because we added a linear model mean statistic in jetstream but no equivalent in partybal